### PR TITLE
Update README.md with more direct download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
 <p align="center">
 First LVM2 and LUKS2 supported arch based distribution. Automatic initcpio hooks to unlock crypted root partition.
 </p>
+
+### <p align="center"> Download ISO images under the <a href="https://github.com/FT-Labs/phyOS-iso/releases/">Releases</a> section.</p>
+
 <hr>
 <p align="center">PLEASE JOIN OUR DISCORD SERVER FOR GUIDES AND RECENT UPDATES.</p>
 


### PR DESCRIPTION
People in the discord proposed the idea of putting a clearer link to the release page containing the ISO for people who aren't as familiar with Github, and I thought it was a good idea. Throwing a pull request in for this simple change. 